### PR TITLE
New Recipes Feature: edit recipe HTML form and JS

### DIFF
--- a/src/main/webapp/edit-recipe.html
+++ b/src/main/webapp/edit-recipe.html
@@ -15,8 +15,20 @@
     <label for="name">What's your recipe called?</label><br/>
     <textarea id="name" name="name" rows="1"></textarea><br/><br/>
 
+    <h2>Description</h2>
+    <label for="description">Give your recipe some more context.</label><br/>
+    <textarea id="description" name="description" rows="3"></textarea><br/><br/>
+
+    <h2>Tags</h2>
+    <div id="tags">
+      <label for="tag1">Tag 1</label></br>
+      <textarea id="tag1" name="tag1" rows="1"></textarea></br></br>
+      <label for="tag2">Tag 2</label></br>
+      <textarea id="tag2" name="tag2" rows="1"></textarea></br></br>
+    </div>
+
     <h2>Ingredients</h2>
-    <div id="steps">
+    <div id="ingredients">
       <label for="ingredient1">Ingredient 1</label></br>
       <textarea id="ingredient1" name="ingredient1" rows="1"></textarea></br></br>
       <label for="ingredient2">Ingredient 2</label></br>
@@ -34,10 +46,6 @@
       <label for="step3">Step 3</label></br>
       <textarea id="step3" name="step3" rows="1"></textarea></br></br>
     </div>
-
-    <h3>Description</h3>
-    <label for="description">Give your recipe some more context.</label><br/>
-    <textarea id="description" name="description" rows="3"></textarea><br/><br/>
 
     <input type="submit"/>
   </form>

--- a/src/main/webapp/edit-recipe.html
+++ b/src/main/webapp/edit-recipe.html
@@ -3,8 +3,8 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Hello world!</title>
-  <link rel="icon" href="/assets/images/shef.png">
+  <title>Edit Recipe</title>
+  <script type="text/javascript" src="script.js"></script>
 </head>
 
 <body>
@@ -49,6 +49,11 @@
 
     <input type="submit"/>
   </form>
+
+  <h1>Populate with original recipe</h1>
+  <label for="key">Recipe Key:</label>
+  <input type="text" id="key"></textarea></br></br>
+  <button onclick="getOriginalRecipe()">Populate</button>
 
 </body>
 </html>

--- a/src/main/webapp/edit-recipe.html
+++ b/src/main/webapp/edit-recipe.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>Hello world!</title>
+  <link rel="icon" href="/assets/images/shef.png">
+</head>
+
+<body>
+  <h1>Edit Recipe!</h1>
+
+  <form action="/new-recipe" method="POST">
+    <h2>Name</h2>
+    <label for="name">What's your recipe called?</label><br/>
+    <textarea id="name" name="name" rows="1"></textarea><br/><br/>
+
+    <h2>Ingredients</h2>
+    <div id="steps">
+      <label for="ingredient1">Ingredient 1</label></br>
+      <textarea id="ingredient1" name="ingredient1" rows="1"></textarea></br></br>
+      <label for="ingredient2">Ingredient 2</label></br>
+      <textarea id="ingredient2" name="ingredient2" rows="1"></textarea></br></br>
+      <label for="ingredient3">Ingredient 3</label></br>
+      <textarea id="ingredient3" name="ingredient3" rows="1"></textarea></br></br>
+    </div>
+
+    <h2>Steps</h2>
+    <div id="steps">
+      <label for="step1">Step 1</label></br>
+      <textarea id="step1" name="step1" rows="1"></textarea></br></br>
+      <label for="step2">Step 2</label></br>
+      <textarea id="step2" name="step2" rows="1"></textarea></br></br>
+      <label for="step3">Step 3</label></br>
+      <textarea id="step3" name="step3" rows="1"></textarea></br></br>
+    </div>
+
+    <h3>Description</h3>
+    <label for="description">Give your recipe some more context.</label><br/>
+    <textarea id="description" name="description" rows="3"></textarea><br/><br/>
+
+    <input type="submit"/>
+  </form>
+
+</body>
+</html>

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -1,0 +1,21 @@
+function getOriginalRecipe() {
+  const key = document.getElementById("key").value;
+  if (key !== "") {
+    fetch("/new-recipe?key=" + key).then(response => response.json()).then((recipe) => {
+      console.log(recipe);
+      populateRecipeCreationForm(recipe);
+    });
+  }
+}
+
+function populateRecipeCreationForm(recipe) {
+  var name = document.getElementById("name");
+  name.value = recipe.name;
+
+  var description = document.getElementById("description");
+  description.value = recipe.name;
+
+  populateFormComponent("tag", recipe.tags);
+  populateFormComponent("ingredient", recipe.ingredients);
+  populateFormComponent("step", recipe.steps);
+}

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -19,3 +19,12 @@ function populateRecipeCreationForm(recipe) {
   populateFormComponent("ingredient", recipe.ingredients);
   populateFormComponent("step", recipe.steps);
 }
+
+function populateFormComponent(componentName, data) {
+  var componentNum = 1;
+  for (var i = 0; i < data.length; i++) {
+    var component = document.getElementById(componentName + componentNum++);
+    console.log(data[i]);
+    component.value = data[i];
+  }
+}


### PR DESCRIPTION
This PR implements the front-end aspect of the recipe creation feature. Users can enter a name, description, list of tags, list of ingredients, and list of steps for their recipe. For now, the number of tags, ingredients, and steps is limited to two, three, and three, respectively, although my next step is to allow users to input as many of each as they like (the back-end has already been designed to support this). Additionally, JavaScript methods can retrieve a recipe's data from the datastore, and populate the form's fields with that recipe's data to create a spin-off. For now, users have to manually enter the parent recipe's datastore key, but eventually, by clicking the spin-off button on the recipe viewing page, the same JavaScript method will be triggered.