### PR TITLE
Multiple keyword search uses AND instead of OR

### DIFF
--- a/src/main/java/servlets/ResultsServlet.java
+++ b/src/main/java/servlets/ResultsServlet.java
@@ -88,6 +88,7 @@ public class ResultsServlet extends HttpServlet {
       queryAsList.add(query);
       filters.add(new FilterPredicate("search-strings", FilterOperator.IN, queryAsList));
     }
-    return new CompositeFilter(CompositeFilterOperator.OR, filters);
+    // Results will contain ALL keywords searched for, as opposed to one or a subset of them.
+    return new CompositeFilter(CompositeFilterOperator.AND, filters);
   }
 }


### PR DESCRIPTION
Changed one line in results servlet; CompositeFilterOperator.OR --> CompositeFilterOperator.AND

Searching for multiple keywords will pull up recipes that contain all keywords, i.e. “walnut, banana” will pull up recipes that include walnut AND banana, as opposed to walnut OR banana.