### PR TITLE
Add Recipe constructor from Datastore Entity

### DIFF
--- a/src/main/java/shef/data/ForYou.java
+++ b/src/main/java/shef/data/ForYou.java
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package shef.data;
+
 public class ForYou implements RecipeFilter {
   
 }

--- a/src/main/java/shef/data/Recipe.java
+++ b/src/main/java/shef/data/Recipe.java
@@ -66,8 +66,6 @@ public class Recipe {
 
   /** Creates a Recipe from a Datastore entity. */
   public Recipe(Entity recipeEntity) {
-    // NOTE: when this is merged, remember to delete the corresponding methods in NewRecipeServlet.java
-    // They'll be left for now so that the servlet is still functional, but should eventually be replaced with this method.
     this.name = (String) recipeEntity.getProperty("name");
     this.description = (String) recipeEntity.getProperty("description");
     this.tags = getTagsFromEntity((Collection<EmbeddedEntity>) recipeEntity.getProperty("tags"));
@@ -244,7 +242,7 @@ public class Recipe {
 
   /** Returns the steps of an EmbeddedEntity as a List. */
   private List<Step> getStepsFromEntity(Collection<EmbeddedEntity> entitySteps) {
-    List<String> stepsList = new LinkedList<>();
+    List<Step> stepsList = new LinkedList<>();
     for (EmbeddedEntity step : entitySteps) {
       stepsList.add(new Step((String) step.getProperty("step")));
     }

--- a/src/main/java/shef/data/Recipe.java
+++ b/src/main/java/shef/data/Recipe.java
@@ -14,12 +14,15 @@
 
 package com.google.sps.data;
 
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.logging.*;
 import java.util.Iterator;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EmbeddedEntity;
 
 /**
  * Stores a recipe's data.
@@ -59,6 +62,18 @@ public class Recipe {
     this.steps = steps;
     this.timestamp = timestamp;
     this.spinOffs = new HashSet<>();
+  }
+
+  /** Creates a Recipe from a Datastore entity. */
+  public Recipe(Entity recipeEntity) {
+    // NOTE: when this is merged, remember to delete the corresponding methods in NewRecipeServlet.java
+    // They'll be left for now so that the servlet is still functional, but should eventually be replaced with this method.
+    this.name = (String) recipeEntity.getProperty("name");
+    this.description = (String) recipeEntity.getProperty("description");
+    this.tags = getTagsFromEntity((Collection<EmbeddedEntity>) recipeEntity.getProperty("tags"));
+    this.ingredients = getIngredientsFromEntity((Collection<EmbeddedEntity>) recipeEntity.getProperty("ingredients"));
+    this.steps = getStepsFromEntity((Collection<EmbeddedEntity>) recipeEntity.getProperty("steps"));
+    this.timestamp = (long) recipeEntity.getProperty("timestamp");
   }
 
   /** Gets the recipe's name. */
@@ -207,6 +222,33 @@ public class Recipe {
    */
   protected boolean isValidStepPosition(int position) {
     return position >= 0 && position < steps.size();
+  }
+
+  /** Returns the tags of an EmbeddedEntity as a Set. */
+  private Set<String> getTagsFromEntity(Collection<EmbeddedEntity> entityTags) {
+    Set<String> tagsSet = new HashSet<>();
+    for (EmbeddedEntity tag : entityTags) {
+      tagsSet.add((String) tag.getProperty("tag"));
+    }
+    return tagsSet;
+  }
+
+  /** Returns the ingredients of an EmbeddedEntity as a Set. */
+  private Set<String> getIngredientsFromEntity(Collection<EmbeddedEntity> entityIngredients) {
+    Set<String> ingredientsSet = new HashSet<>();
+    for (EmbeddedEntity ingredient : entityIngredients) {
+      ingredientsSet.add((String) ingredient.getProperty("ingredient"));
+    }
+    return ingredientsSet;
+  }
+
+  /** Returns the steps of an EmbeddedEntity as a List. */
+  private List<Step> getStepsFromEntity(Collection<EmbeddedEntity> entitySteps) {
+    List<String> stepsList = new LinkedList<>();
+    for (EmbeddedEntity step : entitySteps) {
+      stepsList.add(new Step((String) step.getProperty("step")));
+    }
+    return stepsList;
   }
 
   private void handleStepException(String exceptionText) throws IndexOutOfBoundsException {

--- a/src/main/java/shef/data/Recipe.java
+++ b/src/main/java/shef/data/Recipe.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.sps.data;
+package shef.data;
 
 import java.util.Collection;
 import java.util.LinkedList;

--- a/src/main/java/shef/data/RecipeFilter.java
+++ b/src/main/java/shef/data/RecipeFilter.java
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package shef.data;
+
 public interface RecipeFilter {
   
 }

--- a/src/main/java/shef/data/SpinOff.java
+++ b/src/main/java/shef/data/SpinOff.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.sps.data;
+package shef.data;
 
 public class SpinOff extends Recipe {
 

--- a/src/main/java/shef/data/Step.java
+++ b/src/main/java/shef/data/Step.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.sps.data;
+package shef.data;
 
 public class Step {
 

--- a/src/main/java/shef/data/Trending.java
+++ b/src/main/java/shef/data/Trending.java
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package shef.data;
+
 public class Trending implements RecipeFilter {
   
 }

--- a/src/main/java/shef/servlets/BrowseRecipesServlet.java
+++ b/src/main/java/shef/servlets/BrowseRecipesServlet.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.sps.servlets;
+package shef.servlets;
 
 import javax.servlet.http.HttpServlet;
 

--- a/src/main/java/shef/servlets/NewRecipeServlet.java
+++ b/src/main/java/shef/servlets/NewRecipeServlet.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.sps.servlets;
+package shef.servlets;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -33,8 +33,8 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.ArrayList;
 import java.util.LinkedList;
-import com.google.sps.data.Recipe;
-import com.google.sps.data.Step;
+import shef.data.Recipe;
+import shef.data.Step;
 
 @WebServlet("/new-recipe")
 public class NewRecipeServlet extends HttpServlet {

--- a/src/main/java/shef/servlets/NewRecipeServlet.java
+++ b/src/main/java/shef/servlets/NewRecipeServlet.java
@@ -60,7 +60,7 @@ public class NewRecipeServlet extends HttpServlet {
       e.printStackTrace();
       return;
     }
-    Recipe original = entityToRecipe(recipeEntity);
+    Recipe original = new Recipe(recipeEntity);
     response.setContentType("application/json;");
     response.getWriter().println(convertToJsonUsingGson(original));  
   }
@@ -121,27 +121,6 @@ public class NewRecipeServlet extends HttpServlet {
       return;
     }
     searchStrings.add(stringToAdd.toUpperCase());
-  }
-
-  /** Converts a Datastore entity into a Recipe. */
-  private Recipe entityToRecipe(Entity recipeEntity) {
-    String name = (String) recipeEntity.getProperty("name");
-    String description = (String) recipeEntity.getProperty("description");
-    LinkedHashSet<String> tags = new LinkedHashSet<>((LinkedList<String>) (LinkedList<?>) getDataAsList(recipeEntity.getProperty("tags"), TAG));
-    LinkedHashSet<String> ingredients = new LinkedHashSet<>((LinkedList<String>) (LinkedList<?>) getDataAsList(recipeEntity.getProperty("ingredients"), INGREDIENT));
-    LinkedList<Step> steps = (LinkedList<Step>) (LinkedList<?>) getDataAsList(recipeEntity.getProperty("steps"), STEP);
-    long timestamp = (long) recipeEntity.getProperty("timestamp");
-    return new Recipe(name, description, tags, ingredients, steps, timestamp);
-  }
-
-  /** Gets a list of Recipe parameters from a Datastore property. */
-  private Collection<Object> getDataAsList(Object propertiesObject, String field) {
-    Collection<EmbeddedEntity> properties = (Collection<EmbeddedEntity>) propertiesObject;
-    Collection<Object> dataAsList = new LinkedList<>();
-    for (EmbeddedEntity property : properties) {
-      dataAsList.add(property.getProperty(field));
-    }
-    return dataAsList;
   }
 
   private String convertToJsonUsingGson(Recipe recipe) {

--- a/src/main/webapp/edit-recipe.js
+++ b/src/main/webapp/edit-recipe.js
@@ -173,14 +173,24 @@ function populateRecipeCreationForm(recipe) {
 
 /** Populates the ParamterInputs in a field with a parent recipe's data. */
 function populateFormField(fieldName, data) {
+  console.log(data);
   for (var i = 0; i < data.length; i++) {
     var parameter = document.getElementById(fieldName + i);
     if (parameter !== null) {
-      parameter.text = data[i];
+      parameter.text = getText(data[i]);
     } else {
       var newParameter = createParameterInput(fieldName, i);
-      newParameter.text = data[i];
+      newParameter.text = getText(data[i]);
       appendParameterInput(fieldName + 's', newParameter);
     }
+  }
+}
+
+/** Gets the text of a tag, ingredient, or step. */
+function getText(data) {
+  if (typeof data == 'string') {
+    return data;
+  } else {
+    return data.instruction;
   }
 }

--- a/src/test/java/RecipeTest.java
+++ b/src/test/java/RecipeTest.java
@@ -23,9 +23,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.Arrays;
 import java.util.HashSet;
-import com.google.sps.data.Recipe;
-import com.google.sps.data.SpinOff;
-import com.google.sps.data.Step;
+import shef.data.Recipe;
+import shef.data.SpinOff;
+import shef.data.Step;
 
 @RunWith(JUnit4.class)
 public final class RecipeTest {


### PR DESCRIPTION
I noticed that creating a Recipe object from a Datastore entity is something that multiple different servlets need to do. Previously, NewRecipeServlet had its own private methods for creating Recipe objects, so BrowseRecipesServlet would have had to copy these same methods to create Recipe objects. Instead, this PR adds a constructor to the Recipe class that creates a recipe given a Datastore entity, allowing any servlet to create Recipes from Datastore entities. It also removes the need for the clunky getDataAsList method in NewRecipeServlet, which was ugly in that it required double-casting with an intermediate anonymous collection (LinkedList<?>). getDataAsList is replaced by three separate methods: getTagsFromEntity, getIngredientsFromEntity, and getStepsFromEntity. While these methods are fairly redundant, I expect their behaviors to differentiate in future versions of the recipe class, especially once tags and ingredients are stored as their own classes (instead of Strings) and therefore require different constructors with different parameters.