### PR TITLE
Implement MessageUpdate

### DIFF
--- a/src/main/java/shef/data/MessageUpdate.java
+++ b/src/main/java/shef/data/MessageUpdate.java
@@ -16,6 +16,34 @@ package shef.data;
 
 import java.util.Observable;
 
+/** Handles incoming messages and distributes them to waiting clients. */
 public class MessageUpdate extends Observable {
+
+  private String message;
+
+  public MessageUpdate() {
+    this.message = null;
+  }
+
+  /** 
+   * Sends the message to waiting observers via notifyObservers().
+   * The MessageUpdate is also marked as changed, and is unable to accept new messages until the change is cleared. 
+   */
+  public void sendMessage() {
+    setChanged();
+    notifyObservers(message);
+  }
+
+  /**
+   * If the MessageUpdate has not changed, set the message.
+   * This is to ensure that all messages are sent, even if they're sent at the same time.
+   */
+  public boolean setMessage(String message) {
+    if (hasChanged()) {
+      return false;
+    }
+    this.message = message;
+    return true;
+  }
 
 }

--- a/src/main/java/shef/data/MessageUpdate.java
+++ b/src/main/java/shef/data/MessageUpdate.java
@@ -16,7 +16,12 @@ package shef.data;
 
 import java.util.Observable;
 
-/** Handles incoming messages and distributes them to waiting clients. */
+/**
+ * Handles incoming messages and distributes them to waiting MessagePromises. 
+ * The methods are synchronized to allow only one thread to modify and send a message at a time.
+ * This prevents race conditions where two users post a new message simultaneously, which could allow
+ *     a message to be changed and lost before it is sent.
+ */
 public class MessageUpdate extends Observable {
 
   private String message;
@@ -25,25 +30,15 @@ public class MessageUpdate extends Observable {
     this.message = null;
   }
 
-  /** 
-   * Sends the message to waiting observers via notifyObservers().
-   * The MessageUpdate is also marked as changed, and is unable to accept new messages until the change is cleared. 
-   */
-  public void sendMessage() {
-    setChanged();
+  /** Sends the message to waiting observers via notifyObservers(). */
+  public synchronized void sendMessage() {
     notifyObservers(message);
   }
 
-  /**
-   * If the MessageUpdate has not changed, set the message.
-   * This is to ensure that all messages are sent, even if they're sent at the same time.
-   */
-  public boolean setMessage(String message) {
-    if (hasChanged()) {
-      return false;
-    }
+  /** Set the message and mark the MessageUpdate as changed. */
+  public synchronized void setMessage(String message) {
     this.message = message;
-    return true;
+    setChanged();
   }
 
 }

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -22,9 +22,19 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import shef.data.MessageUpdate;
 
 @WebServlet("/new-message")
 public class NewMessageServlet extends HttpServlet {
+
+  private MessageUpdate messageUpdate;
+  private DatastoreService datastore;
+
+  @Override
+  public void init() {
+    messageUpdate = new MessageUpdate();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {


### PR DESCRIPTION
This PR adds the implementation for the MessageUpdate object. The NewMessageServlet stores a MessageUpdate object that sends new messages to MessagePromises using the Observable pattern. Using Observable.notifyObservers(), the MessageUpdate passes a new message to the observing MessagePromises, which then return the message to their clients. The setMessage() method includes a check using Observable.hasChanged(). This is to prevent bugs where two or more clients may send a message at the same time. By returning a boolean value, setMessage() can be called in a while loop that repeatedly tries to set the message until the MessageUpdate is ready to accept it. The while loop will continue until the first message is sent via notifyObservers(), which internally calls clearChange(). This sets the MessageUpdate's changed value to false, and indicates that it can now accept a new message.