### PR TITLE
implement MessagePromise

### DIFF
--- a/src/main/java/shef/data/MessagePromise.java
+++ b/src/main/java/shef/data/MessagePromise.java
@@ -40,7 +40,7 @@ public class MessagePromise implements Observer {
    * This method waits until it receives a new message from MessageUpdate.
    * It then unblocks, and returns the message to the servlet.
    */
-  synchronized public String getNextMessage() {
+  public synchronized String getNextMessage() {
     // Ensure that the thread waits until an update is detected.
     while (!updated) {
       try {
@@ -56,7 +56,7 @@ public class MessagePromise implements Observer {
 
   /** Receives a new message and then wakes the waiting thread with notify(). */
   @Override
-  synchronized public void update(Observable messageUpdate, Object message) {
+  public synchronized void update(Observable messageUpdate, Object message) {
     this.message = (String) message;
     this.updated = true;
     notify();

--- a/src/main/java/shef/data/MessagePromise.java
+++ b/src/main/java/shef/data/MessagePromise.java
@@ -16,11 +16,49 @@ package shef.data;
 
 import java.util.Observer;
 import java.util.Observable;
+import shef.data.MessageUpdate;
 
+/** 
+ * Returns new messages to GET requests, blocking until they are received from the MessageUpdate. 
+ * Each MessagePromise is used to get one message. 
+ */
 public class MessagePromise implements Observer {
 
-  public void update(Observable messageUpdate, Object newMessage) {
-    
+  private String message;
+  private boolean updated;
+  private MessageUpdate messageUpdate;
+
+  public MessagePromise(MessageUpdate messageUpdate) {
+    this.message = null;
+    this.updated = false;
+    this.messageUpdate = messageUpdate;
+    this.messageUpdate.addObserver(this);
   }
 
+  /**
+   * Gets the next message from the MessageUpdate.
+   * This method waits until it receives a new message from MessageUpdate.
+   * It then unblocks, and returns the message to the servlet.
+   */
+  synchronized public String getNextMessage() {
+    // Ensure that the thread waits until an update is detected.
+    while (!updated) {
+      try {
+        wait();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+
+    messageUpdate.deleteObserver(this);
+    return message;
+  }
+
+  /** Receives a new message and then wakes the waiting thread with notify(). */
+  @Override
+  synchronized public void update(Observable messageUpdate, Object message) {
+    this.message = (String) message;
+    this.updated = true;
+    notify();
+  }
 }

--- a/src/main/java/shef/data/MessageUpdate.java
+++ b/src/main/java/shef/data/MessageUpdate.java
@@ -16,6 +16,7 @@ package shef.data;
 
 import java.util.Observable;
 
+/** Handles incoming messages and distributes them to waiting MessagePromises. */
 public class MessageUpdate extends Observable {
 
 }


### PR DESCRIPTION
This PR implements MessagePromises, which are used to block GET requests from returning until a new message is received. Together with MessageUpdate, they allow for new messages to be retrieved and displayed to the user in real time.