### PR TITLE
Add Groupchat class for auxiliary methods

### DIFF
--- a/src/main/java/shef/data/Groupchat.java
+++ b/src/main/java/shef/data/Groupchat.java
@@ -22,6 +22,12 @@ import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.EntityNotFoundException;
 import java.util.ArrayList;
 
+/**
+ * A wrapper class for Groupchat entities in Datastore.
+ * Groupchat objects hold references to their corresponding Datastore entities and provide methods that
+ *     update both the Groupchat object and entity.
+ * This ensures that Groupchat data is consistent between servlets and Datastore.
+ */
 public class Groupchat {
 
   private ArrayList<String> messages;

--- a/src/main/java/shef/data/Groupchat.java
+++ b/src/main/java/shef/data/Groupchat.java
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shef.data;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+
+public class Groupchat {
+
+  private ArrayList<String> messages;
+
+  public Groupchat(String key) {
+    Entity entity = null;
+    try {
+      entity = datastore.get(KeyFactory.stringToKey(key));
+    } catch (EntityNotFoundException e) {
+      e.printStackTrace();
+      return;
+    }
+    this(entity);
+  }
+
+  public Groupchat(Entity entity) {
+    Object messageObject = entity.getProperty("messages");
+    ArrayList<String> messages = messageObject != null ? (ArrayList<String>) messageObject : new ArrayList<>();
+  }
+
+  public ArrayList<String> getMessages() {
+    return messages;
+  }
+
+}

--- a/src/main/java/shef/data/Groupchat.java
+++ b/src/main/java/shef/data/Groupchat.java
@@ -20,29 +20,38 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.EntityNotFoundException;
+import java.util.ArrayList;
 
 public class Groupchat {
 
   private ArrayList<String> messages;
+  private DatastoreService datastore;
+  private Entity entity;
 
   public Groupchat(String key) {
-    Entity entity = null;
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.entity = null;
     try {
-      entity = datastore.get(KeyFactory.stringToKey(key));
+      this.entity = datastore.get(KeyFactory.stringToKey(key));
     } catch (EntityNotFoundException e) {
       e.printStackTrace();
       return;
     }
-    this(entity);
-  }
 
-  public Groupchat(Entity entity) {
-    Object messageObject = entity.getProperty("messages");
-    ArrayList<String> messages = messageObject != null ? (ArrayList<String>) messageObject : new ArrayList<>();
+    Object messageObject = this.entity.getProperty("messages");
+    this.messages = messageObject != null ? (ArrayList<String>) messageObject : new ArrayList<>();
   }
 
   public ArrayList<String> getMessages() {
     return messages;
   }
 
+  public void addMessage(String message) {
+    messages.add(message);
+    entity.setProperty("messages", messages);
+  }
+
+  public void update() {
+    datastore.put(entity);
+  }
 }


### PR DESCRIPTION
This PR adds an auxiliary Groupchat class to the feature. GroupchatServlet and NewMessageServlet were repeating similar code in retrieving Groupchats from Datastore, so I created this class to make their implementations cleaner. It contains a constructor that allows Groupchats to be created from strings that hold a Datastore key. This constructor handles the case where Entity.getProperty() returns null if a property holds an empty container. The constructor checks if the "messages" property is null, and returns an empty ArrayList if it is. This avoids NullPointerExceptions in the JavaScript.

The Groupchat class also serves as a wrapper class for groupchat Datastore entities. Each Groupchat holds a field with the entity that represents it in Datastore. The methods that manipulate the Groupchat class, like addMessage(), also change the groupchat's underlying entity. The method update() calls datastore.put(entity), so a Datastore entity can be directly updated from an instance of a Groupchat. This allows Groupchat objects and their underlying entities to be changed and updated in one place. If this strategy works cleanly, I'll change the Recipe class to use the same behavior.