### PR TITLE
New message servlet

### DIFF
--- a/src/main/java/shef/data/MessagePromise.java
+++ b/src/main/java/shef/data/MessagePromise.java
@@ -40,7 +40,7 @@ public class MessagePromise implements Observer {
    * This method waits until it receives a new message from MessageUpdate.
    * It then unblocks, and returns the message to the servlet.
    */
-  synchronized public String getNextMessage() {
+  public synchronized String getNextMessage() {
     // Ensure that the thread waits until an update is detected.
     while (!updated) {
       try {
@@ -56,7 +56,7 @@ public class MessagePromise implements Observer {
 
   /** Receives a new message and then wakes the waiting thread with notify(). */
   @Override
-  synchronized public void update(Observable messageUpdate, Object message) {
+  public synchronized void update(Observable messageUpdate, Object message) {
     this.message = (String) message;
     this.updated = true;
     notify();

--- a/src/main/java/shef/data/MessagePromise.java
+++ b/src/main/java/shef/data/MessagePromise.java
@@ -29,7 +29,7 @@ public class MessagePromise implements Observer {
   private MessageUpdate messageUpdate;
 
   public MessagePromise(MessageUpdate messageUpdate) {
-    System.out.println(Thread.currentThread().getName() + ": creating new MessagePromise");
+    //System.out.println(Thread.currentThread().getName() + ": creating new MessagePromise");
     this.message = null;
     this.updated = false;
     this.messageUpdate = messageUpdate;
@@ -47,15 +47,16 @@ public class MessagePromise implements Observer {
     while (!updated) {
       try {
         String name = Thread.currentThread().getName();
-        System.out.println(name + ": before wait()");
+        //System.out.println(name + ": before wait()");
         wait();
-        System.out.println(name + ":after wait()");
+        //System.out.println(name + ":after wait()");
       } catch (Exception e) {
         e.printStackTrace();
       }
     }
 
     messageUpdate.deleteObserver(this);
+    this.updated = false;
     return message;
   }
 

--- a/src/main/java/shef/data/MessagePromise.java
+++ b/src/main/java/shef/data/MessagePromise.java
@@ -29,11 +29,10 @@ public class MessagePromise implements Observer {
   private MessageUpdate messageUpdate;
 
   public MessagePromise(MessageUpdate messageUpdate) {
-    System.out.println("creating new MessagePromise");
+    System.out.println(Thread.currentThread().getName() + ": creating new MessagePromise");
     this.message = null;
     this.updated = false;
     this.messageUpdate = messageUpdate;
-    this.messageUpdate.addObserver(this);
   }
 
   /**
@@ -42,6 +41,8 @@ public class MessagePromise implements Observer {
    * It then unblocks, and returns the message to the servlet.
    */
   public synchronized String getNextMessage() {
+    messageUpdate.addObserver(this);
+
     // Ensure that the thread waits until an update is detected.
     while (!updated) {
       try {
@@ -64,6 +65,6 @@ public class MessagePromise implements Observer {
     this.message = (String) message;
     this.updated = true;
     notify();
-    System.out.println("MessagePromise updated");
+    System.out.println(Thread.currentThread().getName() + ": MessagePromise updated");
   }
 }

--- a/src/main/java/shef/data/MessagePromise.java
+++ b/src/main/java/shef/data/MessagePromise.java
@@ -16,11 +16,49 @@ package shef.data;
 
 import java.util.Observer;
 import java.util.Observable;
+import shef.data.MessageUpdate;
 
+/** 
+ * Returns new messages to GET requests, blocking until they are received from the MessageUpdate. 
+ * Each MessagePromise is used to get one message. 
+ */
 public class MessagePromise implements Observer {
 
-  public void update(Observable messageUpdate, Object newMessage) {
-    
+  private String message;
+  private boolean updated;
+  private MessageUpdate messageUpdate;
+
+  public MessagePromise(MessageUpdate messageUpdate) {
+    this.message = null;
+    this.updated = false;
+    this.messageUpdate = messageUpdate;
+    this.messageUpdate.addObserver(this);
   }
 
+  /**
+   * Gets the next message from the MessageUpdate.
+   * This method waits until it receives a new message from MessageUpdate.
+   * It then unblocks, and returns the message to the servlet.
+   */
+  synchronized public String getNextMessage() {
+    // Ensure that the thread waits until an update is detected.
+    while (!updated) {
+      try {
+        wait();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+
+    messageUpdate.deleteObserver(this);
+    return message;
+  }
+
+  /** Receives a new message and then wakes the waiting thread with notify(). */
+  @Override
+  synchronized public void update(Observable messageUpdate, Object message) {
+    this.message = (String) message;
+    this.updated = true;
+    notify();
+  }
 }

--- a/src/main/java/shef/data/MessagePromise.java
+++ b/src/main/java/shef/data/MessagePromise.java
@@ -29,6 +29,7 @@ public class MessagePromise implements Observer {
   private MessageUpdate messageUpdate;
 
   public MessagePromise(MessageUpdate messageUpdate) {
+    System.out.println("creating new MessagePromise");
     this.message = null;
     this.updated = false;
     this.messageUpdate = messageUpdate;
@@ -44,7 +45,10 @@ public class MessagePromise implements Observer {
     // Ensure that the thread waits until an update is detected.
     while (!updated) {
       try {
+        String name = Thread.currentThread().getName();
+        System.out.println(name + ": before wait()");
         wait();
+        System.out.println(name + ":after wait()");
       } catch (Exception e) {
         e.printStackTrace();
       }
@@ -60,5 +64,6 @@ public class MessagePromise implements Observer {
     this.message = (String) message;
     this.updated = true;
     notify();
+    System.out.println("MessagePromise updated");
   }
 }

--- a/src/main/java/shef/data/MessagePromise.java
+++ b/src/main/java/shef/data/MessagePromise.java
@@ -29,7 +29,6 @@ public class MessagePromise implements Observer {
   private MessageUpdate messageUpdate;
 
   public MessagePromise(MessageUpdate messageUpdate) {
-    //System.out.println(Thread.currentThread().getName() + ": creating new MessagePromise");
     this.message = null;
     this.updated = false;
     this.messageUpdate = messageUpdate;
@@ -46,10 +45,7 @@ public class MessagePromise implements Observer {
     // Ensure that the thread waits until an update is detected.
     while (!updated) {
       try {
-        String name = Thread.currentThread().getName();
-        //System.out.println(name + ": before wait()");
         wait();
-        //System.out.println(name + ":after wait()");
       } catch (Exception e) {
         e.printStackTrace();
       }
@@ -66,6 +62,5 @@ public class MessagePromise implements Observer {
     this.message = (String) message;
     this.updated = true;
     notify();
-    System.out.println(Thread.currentThread().getName() + ": MessagePromise updated");
   }
 }

--- a/src/main/java/shef/data/MessageUpdate.java
+++ b/src/main/java/shef/data/MessageUpdate.java
@@ -16,8 +16,6 @@ package shef.data;
 
 import java.util.Observable;
 
-public class MessageUpdate extends Observable {
-
 /**
  * Handles incoming messages and distributes them to waiting MessagePromises. 
  * The methods are synchronized to allow only one thread to modify and send a message at a time.

--- a/src/main/java/shef/data/MessageUpdate.java
+++ b/src/main/java/shef/data/MessageUpdate.java
@@ -37,9 +37,7 @@ public class MessageUpdate extends Observable {
 
   /** Set the message and mark the MessageUpdate as changed. */
   public void setMessage(String message) {
-    System.out.println("setting MessageUpdate: " + message);
     this.message = message; 
     setChanged();
-    System.out.println("Observers: " + countObservers());
   }
 }

--- a/src/main/java/shef/data/MessageUpdate.java
+++ b/src/main/java/shef/data/MessageUpdate.java
@@ -18,4 +18,28 @@ import java.util.Observable;
 
 public class MessageUpdate extends Observable {
 
+/**
+ * Handles incoming messages and distributes them to waiting MessagePromises. 
+ * The methods are synchronized to allow only one thread to modify and send a message at a time.
+ * This prevents race conditions where two users post a new message simultaneously, which could allow
+ *     a message to be changed and lost before it is sent.
+ */
+public class MessageUpdate extends Observable {
+
+  private String message;
+
+  public MessageUpdate() {
+    this.message = null;
+  }
+
+  /** Sends the message to waiting observers via notifyObservers(). */
+  public synchronized void sendMessage() {
+    notifyObservers(message);
+  }
+
+  /** Set the message and mark the MessageUpdate as changed. */
+  public synchronized void setMessage(String message) {
+    this.message = message;
+    setChanged();
+  }
 }

--- a/src/main/java/shef/data/MessageUpdate.java
+++ b/src/main/java/shef/data/MessageUpdate.java
@@ -31,13 +31,15 @@ public class MessageUpdate extends Observable {
   }
 
   /** Sends the message to waiting observers via notifyObservers(). */
-  public synchronized void sendMessage() {
+  public void sendMessage() {
     notifyObservers(message);
   }
 
   /** Set the message and mark the MessageUpdate as changed. */
-  public synchronized void setMessage(String message) {
-    this.message = message;
+  public void setMessage(String message) {
+    System.out.println("setting MessageUpdate: " + message);
+    this.message = message; 
     setChanged();
+    System.out.println("Observers: " + countObservers());
   }
 }

--- a/src/main/java/shef/servlets/GroupchatServlet.java
+++ b/src/main/java/shef/servlets/GroupchatServlet.java
@@ -17,23 +17,53 @@ package shef.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.gson.Gson;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
 
-@WebServlet("/groupchat")
+@WebServlet("/load-groupchat")
 public class GroupchatServlet extends HttpServlet {
+
+  DatastoreService datastore;
+
+  @Override
+  public void init() {
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String keyString = request.getParameter("key");
+    Entity groupchatEntity = null;
+    try {
+      groupchatEntity = datastore.get(KeyFactory.stringToKey(keyString));
+    } catch (EntityNotFoundException e) {
+      e.printStackTrace();
+      return;
+    }
 
+    ArrayList<String> messages = (ArrayList<String>) groupchatEntity.getProperty("messages");
+    response.setContentType("application/json;");
+    Gson gson = new Gson();
+    response.getWriter().println(gson.toJson(messages));
   }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    
+    Entity groupchat = new Entity("Groupchat");
+    groupchat.setProperty("messages", new ArrayList<String>());
+    datastore.put(groupchat);
+
+    response.setContentType("text/html");
+    String groupchatKey = KeyFactory.keyToString(groupchat.getKey());
+    response.getWriter().println(groupchatKey);  
   }
 
 }

--- a/src/main/java/shef/servlets/GroupchatServlet.java
+++ b/src/main/java/shef/servlets/GroupchatServlet.java
@@ -49,7 +49,8 @@ public class GroupchatServlet extends HttpServlet {
       return;
     }
 
-    ArrayList<String> messages = (ArrayList<String>) groupchatEntity.getProperty("messages");
+    Object messageObject = groupchatEntity.getProperty("messages");
+    ArrayList<String> messages = messageObject != null ? (ArrayList<String>) messageObject : new ArrayList<>();
     response.setContentType("application/json;");
     Gson gson = new Gson();
     response.getWriter().println(gson.toJson(messages));

--- a/src/main/java/shef/servlets/GroupchatServlet.java
+++ b/src/main/java/shef/servlets/GroupchatServlet.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
+import shef.data.Groupchat;
 
 @WebServlet("/load-groupchat")
 public class GroupchatServlet extends HttpServlet {
@@ -41,19 +42,11 @@ public class GroupchatServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String keyString = request.getParameter("key");
-    Entity groupchatEntity = null;
-    try {
-      groupchatEntity = datastore.get(KeyFactory.stringToKey(keyString));
-    } catch (EntityNotFoundException e) {
-      e.printStackTrace();
-      return;
-    }
+    Groupchat group = new Groupchat(keyString);
 
-    Object messageObject = groupchatEntity.getProperty("messages");
-    ArrayList<String> messages = messageObject != null ? (ArrayList<String>) messageObject : new ArrayList<>();
     response.setContentType("application/json;");
     Gson gson = new Gson();
-    response.getWriter().println(gson.toJson(messages));
+    response.getWriter().println(gson.toJson(group.getMessages()));
   }
 
   @Override

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -54,6 +54,7 @@ public class NewMessageServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    System.out.println(Thread.currentThread().getName() + ": GET request made for next mesasge");
     MessagePromise newMessagePromise = new MessagePromise(messageUpdate);
 
     // Blocks until the next message is received.
@@ -86,5 +87,23 @@ public class NewMessageServlet extends HttpServlet {
     messageUpdate.sendMessage();
 
     response.setStatus(response.SC_NO_CONTENT);
+  }
+
+  @Override
+  public void service(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    System.out.println("NEW REQUEST: " + request.getMethod() + " " + request.getRequestURL());
+    if (request.getMethod().equals("ET")) {
+      System.out.println("FOUND ET");
+      doGet(request, response);
+    } else if (request.getMethod().equals("OST")) {
+      System.out.println("FOUND OST");
+      response.sendError(response.SC_BAD_REQUEST);
+    } else {
+      try {
+        super.service(request, response);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
   }
 }

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -40,7 +40,13 @@ public class NewMessageServlet extends HttpServlet {
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    MessagePromise newMessagePromise = new MessagePromise();
 
+    // Blocks until the next message is received.
+    String newMessage = newMessagePromise.getNextMessage();
+
+    response.setContentType("text/html");
+    response.getWriter().println(newMessage);
   }
 
   @Override
@@ -56,7 +62,7 @@ public class NewMessageServlet extends HttpServlet {
     group.addMessage(message);
     group.update();
 
-    // Send message to waiting MessagePromises.
+    // Send new message to waiting MessagePromises.
     messageUpdate.setMessage(message);
     messageUpdate.sendMessage();
 

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -31,6 +31,9 @@ import shef.data.MessageUpdate;
 import shef.data.MessagePromise;
 import shef.data.Groupchat;
 
+import java.util.*;
+import java.text.SimpleDateFormat;
+
 /**
  * This servlet handles new messages, allowing for clients to see them as they're sent in real time.
  * A client sends in new messages with doPost(), and doGet() distributes them to all other active clients.
@@ -40,11 +43,14 @@ public class NewMessageServlet extends HttpServlet {
 
   private MessageUpdate messageUpdate;
   private DatastoreService datastore;
+  private SimpleDateFormat df;
 
   @Override
   public void init() {
     messageUpdate = new MessageUpdate();
     datastore = DatastoreServiceFactory.getDatastoreService();
+    df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    df.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
   }
   
   /**
@@ -54,7 +60,7 @@ public class NewMessageServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    System.out.println(Thread.currentThread().getName() + ": GET request made for next mesasge");
+    System.out.println(Thread.currentThread().getName() + ": GET request made for next message");
     MessagePromise newMessagePromise = new MessagePromise(messageUpdate);
 
     // Blocks until the next message is received.
@@ -89,9 +95,10 @@ public class NewMessageServlet extends HttpServlet {
     response.setStatus(response.SC_NO_CONTENT);
   }
 
-  @Override
+  @Override  
   public void service(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    System.out.println("NEW REQUEST: " + request.getMethod() + " " + request.getRequestURL());
+    String time = df.format(new Date(System.currentTimeMillis()));
+    System.out.println(time + " NEW REQUEST: " + request.getMethod() + " " + request.getRequestURL());
     if (request.getMethod().equals("ET")) {
       System.out.println("FOUND ET");
       doGet(request, response);

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -31,9 +31,6 @@ import shef.data.MessageUpdate;
 import shef.data.MessagePromise;
 import shef.data.Groupchat;
 
-import java.util.*;
-import java.text.SimpleDateFormat;
-
 /**
  * This servlet handles new messages, allowing for clients to see them as they're sent in real time.
  * A client sends in new messages with doPost(), and doGet() distributes them to all other active clients.
@@ -43,14 +40,11 @@ public class NewMessageServlet extends HttpServlet {
 
   private MessageUpdate messageUpdate;
   private DatastoreService datastore;
-  private SimpleDateFormat df;
 
   @Override
   public void init() {
     messageUpdate = new MessageUpdate();
     datastore = DatastoreServiceFactory.getDatastoreService();
-    df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-    df.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
   }
   
   /**
@@ -60,7 +54,6 @@ public class NewMessageServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    System.out.println(Thread.currentThread().getName() + ": GET request made for next message");
     MessagePromise newMessagePromise = new MessagePromise(messageUpdate);
 
     // Blocks until the next message is received.
@@ -93,24 +86,5 @@ public class NewMessageServlet extends HttpServlet {
     messageUpdate.sendMessage();
 
     response.setStatus(response.SC_NO_CONTENT);
-  }
-
-  @Override  
-  public void service(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String time = df.format(new Date(System.currentTimeMillis()));
-    System.out.println(time + " NEW REQUEST: " + request.getMethod() + " " + request.getRequestURL());
-    if (request.getMethod().equals("ET")) {
-      System.out.println("FOUND ET");
-      doGet(request, response);
-    } else if (request.getMethod().equals("OST")) {
-      System.out.println("FOUND OST");
-      response.sendError(response.SC_BAD_REQUEST);
-    } else {
-      try {
-        super.service(request, response);
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-    }
   }
 }

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -50,10 +50,15 @@ public class NewMessageServlet extends HttpServlet {
       return;
     }
 
+    // Upload new message to Datastore.
     String keyString = request.getParameter("groupchat-key");
     Groupchat group = new Groupchat(keyString);
     group.addMessage(message);
     group.update();
+
+    // Send message to waiting MessagePromises.
+    messageUpdate.setMessage(message);
+    messageUpdate.sendMessage();
 
     response.setStatus(response.SC_NO_CONTENT);
   }

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -23,6 +23,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import shef.data.MessageUpdate;
+import shef.data.MessagePromise;
+import shef.data.Groupchat;
 
 @WebServlet("/new-message")
 public class NewMessageServlet extends HttpServlet {
@@ -48,16 +50,12 @@ public class NewMessageServlet extends HttpServlet {
       return;
     }
 
-    String keyString = request.getParameter("key");
-    Entity groupchatEntity = null;
-    try {
-      groupchatEntity = datastore.get(KeyFactory.stringToKey(keyString));
-    } catch (EntityNotFoundException e) {
-      e.printStackTrace();
-      return;
-    }
-    Object messageObject = groupchatEntity.getProperty("messages");
-    ArrayList<String> messages = messageObject != null ? (ArrayList<String>) messageObject : new ArrayList<>();
+    String keyString = request.getParameter("groupchat-key");
+    Groupchat group = new Groupchat(keyString);
+    group.addMessage(message);
+    group.update();
+
+    response.setStatus(response.SC_NO_CONTENT);
   }
 
 }

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -22,9 +22,19 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import shef.data.MessageUpdate;
 
 @WebServlet("/new-message")
 public class NewMessageServlet extends HttpServlet {
+
+  private MessageUpdate messageUpdate;
+  private DatastoreService datastore;
+
+  @Override
+  public void init() {
+    messageUpdate = new MessageUpdate();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -43,7 +43,21 @@ public class NewMessageServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    
+    String message = request.getParameter("message");
+    if (message.equals("")) {
+      return;
+    }
+
+    String keyString = request.getParameter("key");
+    Entity groupchatEntity = null;
+    try {
+      groupchatEntity = datastore.get(KeyFactory.stringToKey(keyString));
+    } catch (EntityNotFoundException e) {
+      e.printStackTrace();
+      return;
+    }
+    Object messageObject = groupchatEntity.getProperty("messages");
+    ArrayList<String> messages = messageObject != null ? (ArrayList<String>) messageObject : new ArrayList<>();
   }
 
 }

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -54,7 +54,7 @@ public class NewMessageServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    MessagePromise newMessagePromise = new MessagePromise();
+    MessagePromise newMessagePromise = new MessagePromise(messageUpdate);
 
     // Blocks until the next message is received.
     String newMessage = newMessagePromise.getNextMessage();

--- a/src/main/java/shef/servlets/NewMessageServlet.java
+++ b/src/main/java/shef/servlets/NewMessageServlet.java
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/*
+ * The following source informed the architecture of this servlet and its functional components:
+ * https://docstore.mik.ua/orelly/java-ent/servlet/ch10_03.htm
+ */
+
 package shef.servlets;
 
 import com.google.appengine.api.datastore.DatastoreService;
@@ -26,6 +31,10 @@ import shef.data.MessageUpdate;
 import shef.data.MessagePromise;
 import shef.data.Groupchat;
 
+/**
+ * This servlet handles new messages, allowing for clients to see them as they're sent in real time.
+ * A client sends in new messages with doPost(), and doGet() distributes them to all other active clients.
+ */
 @WebServlet("/new-message")
 public class NewMessageServlet extends HttpServlet {
 
@@ -38,6 +47,11 @@ public class NewMessageServlet extends HttpServlet {
     datastore = DatastoreServiceFactory.getDatastoreService();
   }
   
+  /**
+   * Waits for incoming messages using MessagePromises.
+   * Each GET request instantiates a MessagePromise, which blocks until a new message is received.
+   * The MessagePromise then unblocks and allows the GET request to respond with the new message.
+   */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     MessagePromise newMessagePromise = new MessagePromise();
@@ -49,6 +63,11 @@ public class NewMessageServlet extends HttpServlet {
     response.getWriter().println(newMessage);
   }
 
+  /**
+   * Posts new messages to Datastore and distributes them to active clients using MessageUpdates.
+   * The message is first added to the groupchat in Datastore, and then distributed to the waiting MessagePromises.
+   * Empty messages are ignored.
+   */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String message = request.getParameter("message");
@@ -68,5 +87,4 @@ public class NewMessageServlet extends HttpServlet {
 
     response.setStatus(response.SC_NO_CONTENT);
   }
-
 }

--- a/src/main/webapp/groupchat.html
+++ b/src/main/webapp/groupchat.html
@@ -15,6 +15,7 @@
     <form action="/new-message" method="POST" style="position: absolute; bottom: 10px; width: 100%">
       <label for="message-input">Type a message:</label></br>
       <textarea id="message-input" name="message" rows="5" style="width: 99%"></textarea>
+      <input type="hidden" name="groupchat-key" id="groupchat-key"></input>
       <input type="submit"></input>
     </form>
   </body>

--- a/src/main/webapp/groupchat.html
+++ b/src/main/webapp/groupchat.html
@@ -8,7 +8,7 @@
     <script type="text/javascript" src="script.js"></script>
   </head>
 
-  <body>
+  <body onload="loadGroupchat()">
     <h1>Groupchat</h1>
     <div id="messages"></div>
 

--- a/src/main/webapp/groupchat.html
+++ b/src/main/webapp/groupchat.html
@@ -10,5 +10,12 @@
 
   <body>
     <h1>Groupchat</h1>
+    <div id="messages"></div>
+
+    <form action="/new-message" method="POST" style="position: absolute; bottom: 10px; width: 100%">
+      <label for="message-input">Type a message:</label></br>
+      <textarea id="message-input" name="message" rows="5" style="width: 99%"></textarea>
+      <input type="submit"></input>
+    </form>
   </body>
 </html>

--- a/src/main/webapp/groupchat.html
+++ b/src/main/webapp/groupchat.html
@@ -5,18 +5,18 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>shef</title>
-    <script type="text/javascript" src="script.js"></script>
+    <script type="text/javascript" src="script.js" onload="loadGroupchat()"></script>
   </head>
 
-  <body onload="loadGroupchat()">
+  <body>
     <h1>Groupchat</h1>
     <div id="messages"></div>
 
-    <form action="/new-message" method="POST" style="position: absolute; bottom: 10px; width: 100%">
+    <form onsubmit="postNextMessage();return false" style="position: absolute; bottom: 10px; width: 100%">
       <label for="message-input">Type a message:</label></br>
       <textarea id="message-input" name="message" rows="5" style="width: 99%"></textarea>
-      <input type="hidden" name="groupchat-key" id="groupchat-key"></input>
-      <input type="submit"></input>
+      <input type="hidden" name="groupchat-key" id="groupchat-key"/>
+      <input type="submit"/>
     </form>
   </body>
 </html>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>shef</title>
+    <script type="text/javascript" src="script.js"></script>
+  </head>
+
+  <body>
+    <h1>Groupchat Options</h1>
+    <h3>Create new groupchat</h3>
+    <button onclick="newGroupchat()">New Groupchat</button></br></br>
+
+    <h3>Load groupchat</h3>
+    <label for="groupchat-key">Groupchat Key:</label>
+    <input type="text" id="groupchat-key"></input></br></br>
+    <button onclick="redirectToGroupchat()">Go!</button>
+
+    <div id="messages"></div>
+  </body>
+</html>

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -38,3 +38,33 @@ function createCommentElement(comment) {
 function addParagraph(content) {
   return "<p>" + content + "</p>";
 }
+
+function newGroupchat() {
+  const request = new Request("/load-groupchat", {method: 'POST'});
+  fetch(request).then(response => response.text()).then((key) => {
+    redirectToGroupchat(key);
+  });
+}
+
+function loadGroupchat() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const key = urlParams.get('key');
+  fetch('/load-groupchat?key=' + key).then(response => response.json())
+    .catch(error => {
+      alert('Error: Groupchat does not exist');
+      window.location.href = 'index.html';
+    }).then((messages) => {
+      const messageContainer = document.getElementById('messages');
+      messageContainer.innerHTML = '';
+      for (var i = 0; i < messages.length; i++) {
+        const message = document.createElement('p');
+        message.innerText = messages[i];
+        messageContainer.appendChild(message);
+      }
+  });
+}
+
+function redirectToGroupchat(keyParameter) {
+  const key = keyParameter ? keyParameter : document.getElementById('groupchat-key').value;
+  window.location.href = "/groupchat.html?key=" + key;
+}

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -54,18 +54,40 @@ function loadGroupchat() {
       alert('Error: Groupchat does not exist');
       window.location.href = 'index.html';
     }).then((messages) => {
-      var messageContainer = document.getElementById('messages');
-      messageContainer.innerHTML = '';
+      document.getElementById('messages').innerHTML = '';
       document.getElementById('groupchat-key').value = key;
       for (var i = 0; i < messages.length; i++) {
-        const message = document.createElement('p');
-        message.innerText = messages[i];
-        messageContainer.appendChild(message);
+        addMessage(messages[i]);
       }
+      setTimeout(getNextMessage(), 100);
   });
+}
+
+function getNextMessage() {
+  console.log('getting a new message');
+  const request = new Request("/new-message", {method: 'GET'})
+  console.log("Request: " + request);
+  fetch(request)
+    .then(response => {
+      console.log("In response => response.text() block")
+      return response.text()
+    }, err => alert('servlet error ' + err))
+    .then(message => {
+      console.log('got message ' + message);
+      addMessage(message);
+      getNextMessage();
+    }, err => alert('text() error ' + err));
+  console.log("outside of fetch block");
 }
 
 function redirectToGroupchat(keyParameter) {
   const key = keyParameter ? keyParameter : document.getElementById('groupchat-key').value;
   window.location.href = "/groupchat.html?key=" + key;
+}
+
+function addMessage(message) {
+  var messagesContainer = document.getElementById('messages');
+  const messageElement = document.createElement('p');
+  messageElement.innerText = message;
+  messagesContainer.appendChild(messageElement);
 }

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -39,6 +39,7 @@ function addParagraph(content) {
   return "<p>" + content + "</p>";
 }
 
+/** Creates a new groupchat and redirects the client to the chatting page. */
 function newGroupchat() {
   var request = new Request("/load-groupchat", {method: 'POST'});
   fetch(request).then(response => response.text()).then((key) => {
@@ -46,6 +47,7 @@ function newGroupchat() {
   });
 }
 
+/** Loads an existing groupchat. */
 function loadGroupchat() {
   const urlParams = new URLSearchParams(window.location.search);
   const key = urlParams.get('key');
@@ -63,44 +65,47 @@ function loadGroupchat() {
   });
 }
 
+/** Posts a message to a groupchat. */
 function postNextMessage() {
   const message = document.getElementById('message-input').value;
   const groupKey = document.getElementById('groupchat-key').value;
   var request = new Request('/new-message?message=' + message + '&groupchat-key=' + groupKey, {method: 'POST'});
-  fetch(request)
-    .then(() => {
-      console.log('POST success');
-      document.getElementById('message-input').value = '';
-      }, () => console.log('POST failure'));
+  fetch(request).then(
+    document.getElementById('message-input').value = ''
+  );
 }
 
+/**
+ * Sends a request to the server to get the next message.
+ * This method is recursive (upon success) so that each client is always waiting for the next message.
+ * Requests use asynchronous Promises, so the client can perform other functions while waiting for a message.
+ */
 function getNextMessage() {
-  console.log('getting a new message');
   var request = new Request("/new-message", {method: 'GET'})
-  console.log('sending request ' + request.url + ' ' + request.method);
   fetch(request)
     .then(response => {
       if (response.ok) {
-        console.log("Received response " + response);
         return response.text();
       } else {
         throw new Error('Servlet closed');
       }
-    })
-    .then(message => {
-      console.log('Got message "' + message + '"');
+    }).then(message => {
       addMessage(message);
-      console.log('recursively calling getNextMessage()')
       getNextMessage();
     })
-    .catch(err => console.log(err));
+    .catch(err => {
+      alert(err);
+      window.location.href = 'index.html';
+    });
 }
 
+/** Given a groupchat key, redirects the client to that groupchat. */
 function redirectToGroupchat(keyParameter) {
   const key = keyParameter ? keyParameter : document.getElementById('groupchat-key').value;
   window.location.href = "/groupchat.html?key=" + key;
 }
 
+/** Adds a <p> element containing a message to a groupchat. */
 function addMessage(message) {
   var messagesContainer = document.getElementById('messages');
   const messageElement = document.createElement('p');

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -68,25 +68,32 @@ function postNextMessage() {
   const groupKey = document.getElementById('groupchat-key').value;
   var request = new Request('/new-message?message=' + message + '&groupchat-key=' + groupKey, {method: 'POST'});
   fetch(request)
-    .then(v => console.log('POST success'), v => console.log('POST failure'));
+    .then(() => {
+      console.log('POST success');
+      document.getElementById('message-input').value = '';
+      }, () => console.log('POST failure'));
 }
 
 function getNextMessage() {
   console.log('getting a new message');
   var request = new Request("/new-message", {method: 'GET'})
+  console.log('sending request ' + request.url + ' ' + request.method);
   fetch(request)
     .then(response => {
-      console.log("In response => response.text() block");
-      return response.text();
-    }, error => {
-      console.log('SERVER ERROR: ' + error);
-      //getNextMessage();
+      if (response.ok) {
+        console.log("Received response " + response);
+        return response.text();
+      } else {
+        throw new Error('Servlet closed');
+      }
     })
     .then(message => {
-      console.log('got message "' + message + '"');
+      console.log('Got message "' + message + '"');
       addMessage(message);
+      console.log('recursively calling getNextMessage()')
       getNextMessage();
-    }, err => alert('text() error ' + err));
+    })
+    .catch(err => console.log(err));
 }
 
 function redirectToGroupchat(keyParameter) {

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -1,6 +1,6 @@
 // Copyright 2019 Google LLC
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the 'License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -49,19 +49,18 @@ function newGroupchat() {
 function loadGroupchat() {
   const urlParams = new URLSearchParams(window.location.search);
   const key = urlParams.get('key');
-  fetch('/load-groupchat?key=' + key).then(response => response.json())
-    .catch(error => {
-      alert('Error: Groupchat does not exist');
-      window.location.href = 'index.html';
-    }).then((messages) => {
-      const messageContainer = document.getElementById('messages');
-      messageContainer.innerHTML = '';
-      for (var i = 0; i < messages.length; i++) {
-        const message = document.createElement('p');
-        message.innerText = messages[i];
-        messageContainer.appendChild(message);
-      }
-  });
+  fetch('/load-groupchat?key=' + key).then(response => response.json()).then((messages) => {
+    const messageContainer = document.getElementById('messages');
+    messageContainer.innerHTML = '';
+    for (var i = 0; i < messages.length; i++) {
+      const message = document.createElement('p');
+      message.innerText = messages[i];
+      messageContainer.appendChild(message);
+    }
+  }).catch(error =>
+    alert('Error: Groupchat does not exist')
+  );
+
 }
 
 function redirectToGroupchat(keyParameter) {

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -40,7 +40,7 @@ function addParagraph(content) {
 }
 
 function newGroupchat() {
-  const request = new Request("/load-groupchat", {method: 'POST'});
+  var request = new Request("/load-groupchat", {method: 'POST'});
   fetch(request).then(response => response.text()).then((key) => {
     redirectToGroupchat(key);
   });
@@ -49,9 +49,9 @@ function newGroupchat() {
 function loadGroupchat() {
   const urlParams = new URLSearchParams(window.location.search);
   const key = urlParams.get('key');
-  fetch('/load-groupchat?key=' + key).then(response => response.json())
-    .catch(error => {
-      alert('Error: Groupchat does not exist');
+  fetch('/load-groupchat?key=' + key)
+    .then(response => response.json(), error => {
+      alert('Error: Groupchat does not exist ' + error);
       window.location.href = 'index.html';
     }).then((messages) => {
       document.getElementById('messages').innerHTML = '';
@@ -59,25 +59,35 @@ function loadGroupchat() {
       for (var i = 0; i < messages.length; i++) {
         addMessage(messages[i]);
       }
-      setTimeout(getNextMessage(), 100);
+      getNextMessage();
   });
+}
+
+function postNextMessage() {
+  const message = document.getElementById('message-input').value;
+  const groupKey = document.getElementById('groupchat-key').value;
+  var request = new Request('/new-message?message=' + message + '&groupchat-key=' + groupKey, {method: 'POST'});
+  fetch(request)
+    .then(v => console.log('POST success'), v => console.log('POST failure'));
 }
 
 function getNextMessage() {
   console.log('getting a new message');
-  const request = new Request("/new-message", {method: 'GET'})
+  var request = new Request("/new-message", {method: 'GET'})
   console.log("Request: " + request);
   fetch(request)
     .then(response => {
-      console.log("In response => response.text() block")
-      return response.text()
-    }, err => alert('servlet error ' + err))
+      console.log("In response => response.text() block");
+      return response.text();
+    }, error => {
+      console.log('SERVER ERROR: ' + error);
+      //getNextMessage();
+    })
     .then(message => {
       console.log('got message ' + message);
       addMessage(message);
       getNextMessage();
     }, err => alert('text() error ' + err));
-  console.log("outside of fetch block");
 }
 
 function redirectToGroupchat(keyParameter) {

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -54,8 +54,8 @@ function loadGroupchat() {
       alert('Error: Groupchat does not exist');
       window.location.href = 'index.html';
     }).then((messages) => {
-      const messageContainer = document.getElementById('messages');
-      messageContainer.innerHTML = '';
+      document.getElementById('messages').innerHTML = '';
+      document.getElementById('groupchat-key').value = key;
       for (var i = 0; i < messages.length; i++) {
         const message = document.createElement('p');
         message.innerText = messages[i];

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -54,7 +54,8 @@ function loadGroupchat() {
       alert('Error: Groupchat does not exist');
       window.location.href = 'index.html';
     }).then((messages) => {
-      document.getElementById('messages').innerHTML = '';
+      var messageContainer = document.getElementById('messages');
+      messageContainer.innerHTML = '';
       document.getElementById('groupchat-key').value = key;
       for (var i = 0; i < messages.length; i++) {
         const message = document.createElement('p');

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -49,18 +49,19 @@ function newGroupchat() {
 function loadGroupchat() {
   const urlParams = new URLSearchParams(window.location.search);
   const key = urlParams.get('key');
-  fetch('/load-groupchat?key=' + key).then(response => response.json()).then((messages) => {
-    const messageContainer = document.getElementById('messages');
-    messageContainer.innerHTML = '';
-    for (var i = 0; i < messages.length; i++) {
-      const message = document.createElement('p');
-      message.innerText = messages[i];
-      messageContainer.appendChild(message);
-    }
-  }).catch(error =>
-    alert('Error: Groupchat does not exist')
-  );
-
+  fetch('/load-groupchat?key=' + key).then(response => response.json())
+    .catch(error => {
+      alert('Error: Groupchat does not exist');
+      window.location.href = 'index.html';
+    }).then((messages) => {
+      const messageContainer = document.getElementById('messages');
+      messageContainer.innerHTML = '';
+      for (var i = 0; i < messages.length; i++) {
+        const message = document.createElement('p');
+        message.innerText = messages[i];
+        messageContainer.appendChild(message);
+      }
+  });
 }
 
 function redirectToGroupchat(keyParameter) {

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -74,7 +74,6 @@ function postNextMessage() {
 function getNextMessage() {
   console.log('getting a new message');
   var request = new Request("/new-message", {method: 'GET'})
-  console.log("Request: " + request);
   fetch(request)
     .then(response => {
       console.log("In response => response.text() block");
@@ -84,7 +83,7 @@ function getNextMessage() {
       //getNextMessage();
     })
     .then(message => {
-      console.log('got message ' + message);
+      console.log('got message "' + message + '"');
       addMessage(message);
       getNextMessage();
     }, err => alert('text() error ' + err));


### PR DESCRIPTION
This PR creates the servlet that handles new messages, bringing together MessagePromises and MessageUpdates to provide group chat functionality. In summary, clients send GET requests to the servlet, which creates a MessagePromise for each GET request. These MessagePromises block, so their GET requests are unable to respond to the client until they are awakened. When a client sends a new message via a POST request, the servlet stores the message in a MessageUpdate object. The MessageUpdate wakes each waiting MessagePromise and copies the message into it, allowing them to return the new message to the client. Upon successfully receiving a response, clients immediately send another GET request, so they are always waiting for the next message. 

I relied on the following source to help implement this feature, particularly to understand how to use the observer pattern: [https://docstore.mik.ua/orelly/java-ent/servlet/ch10_03.htm](url).

_Known issue_: When multiple clients are on a group chat, all but one of the client's GET requests are received by the server at the expected time. Testing showed that the clients all send their requests at the same time via fetch(), but the servlet consistently receives one, stalls for ~20 seconds, and then receives the remaining requests all at once. Sending a message within this 20 second period results in only one client seeing it (the sole client whose request was received), but if messages occur at least 20 seconds after each other, the group chat behaves as expected. After discussing with a VSE, I think this might have to do with a limit that the browser places on the number of requests that can be sent to a URL in a certain time frame.